### PR TITLE
Add build script so no CLI install required

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "webpack",
     "start": "webpack-dev-server"
   },
   "repository": {


### PR DESCRIPTION
Now you can run `npm run-script build` to invoke webpack. If there are any additional args required please let me know.